### PR TITLE
Fix setup of project to reproduce bug

### DIFF
--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -1,14 +1,8 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 
-sourceCompatibility = '1.10'
-targetCompatibility = '1.10'
-
-repositories {
-    maven {
-        url "file://$projectDir/../repo"
-    }
-}
+sourceCompatibility = '10'
+targetCompatibility = '10'
 
 dependencies {
-    compile 'com.company:mylib:1.0'
+    implementation project(':producer')
 }

--- a/producer/build.gradle
+++ b/producer/build.gradle
@@ -1,22 +1,9 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 
 group = 'com.company'
 version = '1.0'
 
-sourceCompatibility = '1.10'
-targetCompatibility = '1.10'
+sourceCompatibility = '10'
+targetCompatibility = '10'
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            from components.java
-        }
-    }
-    
-    repositories {
-        maven {
-            url "file://$projectDir/../repo"
-        }
-    }
-}

--- a/producer/settings.gradle
+++ b/producer/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'mylib'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,5 @@
+rootProject.name = 'java10'
+
+include 'producer'
+include 'consumer'
+


### PR DESCRIPTION
This changes the setup of the reproduction project to show that Gradle cannot recognize JDK 10 class files.

Just run `gradle build`, and it will issue this warning:

> Malformed class file [MyUtil.class] found on compile classpath, which means that this class will cause a compile error if referenced in a source file. Gradle 5.0 will no longer allow malformed classes on compile classpath.

Because Gradle caches snapshotting, you should make sure to update the source file to see the message appear.

See https://scans.gradle.com/s/h4cwwyqkytqza/console-log